### PR TITLE
Remove mkdir from rules build

### DIFF
--- a/recipe/RULES_BUILD_remove_mkdir.patch
+++ b/recipe/RULES_BUILD_remove_mkdir.patch
@@ -1,0 +1,13 @@
+diff --git a/configure/RULES_BUILD b/configure/RULES_BUILD
+index e38bbcf08..46e2947f9 100644
+--- a/configure/RULES_BUILD
++++ b/configure/RULES_BUILD
+@@ -332,7 +332,7 @@ $(LOADABLE_SHRLIBNAME): $(LOADABLE_SHRLIB_PREFIX)%$(LOADABLE_SHRLIB_SUFFIX):
+ 
+ $(LIBNAME) $(SHRLIBNAME) $(LOADABLE_SHRLIBNAME): | $(INSTALL_LIB)
+ $(INSTALL_LIB):
+-	@$(MKDIR) $@
++#	@$(MKDIR) $@
+ 
+ #---------------------------------------------------------------
+ # C++ munching for VxWorks

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: acd62c9b97b60caea9303cc3aab922dbf2bc3bfb3d20e0027110ffe4c906a6c7
   patches:
     - RULES_MODULES_echo_quotes.patch
+    - RULES_BUILD_remove_mkdir.patch
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage('epics-base', max_pin='x.x.x.x') }}
 


### PR DESCRIPTION
This patch fixes an issue in a downstream application where the library directory was being created too early. The mkdir rule is only present upstream (in the EPICS base source) to silence a warning on macOS.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
