### PR TITLE
Fix downstream tests in p4p

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/recipe/initialise_pthreadInfo_attr.patch
+++ b/recipe/initialise_pthreadInfo_attr.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/libcom/src/osi/os/posix/osdThread.c b/modules/libcom/src/osi/os/posix/osdThread.c
+index e9ea2dfbc..5a7f6f307 100644
+--- a/modules/libcom/src/osi/os/posix/osdThread.c
++++ b/modules/libcom/src/osi/os/posix/osdThread.c
+@@ -665,6 +665,8 @@ static epicsThreadOSD *createImplicit(void)
+     assert(pthreadInfo);
+     pthreadInfo->tid = tid;
+     pthreadInfo->osiPriority = 0;
++    status = pthread_attr_init(&pthreadInfo->attr);
++    checkStatusOnce(status,"pthread_attr_init");
+ 
+ #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
+     if(pthread_getschedparam(tid,&pthreadInfo->schedPolicy,&pthreadInfo->schedParam) == 0) {

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
   patches:
     - RULES_MODULES_echo_quotes.patch
     - RULES_BUILD_remove_mkdir.patch
+    - initialise_pthreadInfo_attr.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage('epics-base', max_pin='x.x.x.x') }}
 


### PR DESCRIPTION
Some of the p4p tests hang for python 3.13: specifically we see errors that look like
```
test_get (p4p.test.test_gw.TestHighLevel.test_get) ... pthread_attr_destroy  ERROR Invalid argument
free_threadInfoCRITICAL ERROR Thread non-EPICS_6358691840 (0x120a081f0) can't proceed, suspending.
Dumping a stack trace of thread 'non-EPICS_6358691840':
[       0x103fad2cc]: /Users/simonrose/miniconda3/envs/cb/conda-bld/debug_1756896063925/_h_env/epics/lib/darwin-aarch64/libCom.3.24.0.dylib(epicsStackTrace+0x74)
[       0x103f9eacc]: /Users/simonrose/miniconda3/envs/cb/conda-bld/debug_1756896063925/_h_env/epics/lib/darwin-aarch64/libCom.3.24.0.dylib(cantProceed+0x44)
[       0x103fa84c0]: /Users/simonrose/miniconda3/envs/cb/conda-bld/debug_1756896063925/_h_env/epics/lib/darwin-aarch64/libCom.3.24.0.dylib(free_threadInfo+0x13c)
[       0x183874870]: /usr/lib/system/libsystem_pthread.dylib(_pthread_tsd_cleanup+0x1e8)
[       0x183877684]: /usr/lib/system/libsystem_pthread.dylib(_pthread_exit+0x54)
[       0x183876fa0]: /usr/lib/system/libsystem_pthread.dylib(_pthread_start+0x94)
[       0x183871d34]: /usr/lib/system/libsystem_pthread.dylib(thread_start+0x8)
```
This happens for both osx-64 and osx-arm64 targets (but not linux), and appears to be due to not properly initialising implicit thread objects correctly. This patch fixes these tests.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Closes https://github.com/epics-base/p4p/issues/179 and https://github.com/conda-forge/p4p-feedstock/issues/57 (once this is merged and pvxs is rebuilt...)

