### PR TITLE
Move Windows lib files to canonical locations

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,8 @@ if %ARCH%==32 (
     set EPICS_HOST_ARCH=windows-x64
 )
 
+set EPICS_BASE=%PREFIX%\epics
+
 REM SCRIPTS causes failure of GNU make
 set SCRIPTS=
 
@@ -17,3 +19,9 @@ if errorlevel 1 (
     echo MAKE FAILED
     exit /b 1
 )
+
+mkdir "%PREFIX%\Library\bin" >nul
+mkdir "%PREFIX%\Library\lib" >nul
+
+copy "%EPICS_BASE%\bin\%EPICS_HOST_ARCH%\*.dll" "%PREFIX%\Library\bin\" >nul
+copy "%EPICS_BASE%\lib\%EPICS_HOST_ARCH%\*.lib" "%PREFIX%\Library\lib\" >nul

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - initialise_pthreadInfo_attr.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage('epics-base', max_pin='x.x.x.x') }}
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The intention behind this PR is to get rid of a workaround in PVXS' feedstock
```
rem We need to copy the DLLs from EPICS base
copy "%EPICS_BASE%\bin\%EPICS_HOST_ARCH%\*.dll" "%PREFIX%\bin\" >nul
copy "include\pvxs\*"                           "%PREFIX%\include\pvxs\" >nul
copy "dbd\*"                                    "%PREFIX%\pvxs\dbd\" >nul
copy "db\*"                                     "%PREFIX%\pvxs\db\" >nul
```
but also for p4p's cython extensions to be able to find the DLLs.