### PR TITLE
Add -std=gnu17 flag to C builds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,8 @@ EOF
 fi
 
 cat << EOF >> configure/os/CONFIG_SITE.Common.linuxCommon
+# GCC15 defaults to gnu23 but EPICS ecosystem needs gnu17
+POSIX_CFLAGS += -std=gnu17
 # Set GNU_DIR to BUILD_PREFIX or PREFIX if not set (when not using conda-build)
 # Allow to compile without conda-build by installing manually the compilers
 # in a local conda environment
@@ -48,6 +50,8 @@ CCC = ${CXX}
 AR = ${AR} -rc
 RANLIB = ${RANLIB}
 
+# GCC15 defaults to gnu23 but EPICS ecosystem needs gnu17
+POSIX_CFLAGS += -std=gnu17
 OP_SYS_CFLAGS += -isysroot \${CONDA_BUILD_SYSROOT} -mmacosx-version-min=\${MACOSX_DEPLOYMENT_TARGET}
 OP_SYS_CXXFLAGS += -isysroot \${CONDA_BUILD_SYSROOT} -mmacosx-version-min=\${MACOSX_DEPLOYMENT_TARGET}
 OP_SYS_LDFLAGS += -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ source:
     - test_dbtemplate_fix_relative_path_tests.patch
 
 build:
-  number: 8
+  number: 9
 
 outputs:
   - package:


### PR DESCRIPTION
The epics ecosystem is not prepared for a jump to gnu23. With GCC15.1 being the standard in conda this is needed for building most EPICS modules.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
