### PR TITLE
Fetch the source from the GitHub release asset

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,15 +3,23 @@
 schema_version: 1
 
 context:
+  name: epics-base
   version: 7.0.9.0
 
 recipe:
-  name: epics-base
+  name: ${{ name }}
   version: ${{ version }}
 
 source:
-  # Don't use {{ version }} in the url as it can be on 3 numbers only
-  url: https://epics-controls.org/download/base/base-7.0.9.tar.gz
+  # The recipe version always carries 4 numbers to match run_exports, while
+  # upstream omits a zero patch level from release names (7.0.9, not 7.0.9.0)
+  # - so don't template the version into the URL.
+  # Upstream's release asset bundles the submodules, unlike the auto-generated
+  # tag archive.
+  # Prefer the GitHub release asset over epics-controls.org: GH can re-cut
+  # assets after the initial publish, while epics-controls keeps the first
+  # cut and will then fail the recorded sha256 (useless as a mirror).
+  url: https://github.com/epics-base/${{ name }}/releases/download/R7.0.9/base-7.0.9.tar.gz
   sha256: acd62c9b97b60caea9303cc3aab922dbf2bc3bfb3d20e0027110ffe4c906a6c7
   patches:
     - RULES_MODULES_echo_quotes.patch
@@ -25,7 +33,7 @@ source:
         - skip_testCaProvider_on_windows.patch
 
 build:
-  number: 12
+  number: 13
 
 outputs:
   - package:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Supersedes #49; second attempt at the goal of 0bf83e1359bef3d8464c7cf98233cf9e33f66f89 (build from a GitHub source instead of epics-controls.org).

#49 established why the auto-generated tag archive (`archive/refs/tags/R7.0.9.tar.gz`) cannot work: the submodules are not included in the archive (and `.gitmodules` is explicitly excluded via `.gitattributes`), so EPICS base builds *without* the PVA modules — the top-level Makefile silently skips the missing directories — and only the test phase catches the absence of `pvget`/`softIocPVA`/`p2p`. Jobs that skip the test phase (the cross-compiled variants) go green while producing a crippled package, which is why #49's CI looked partially successful.

This PR uses upstream's **release asset** instead: `https://github.com/epics-base/epics-base/releases/download/R7.0.9/base-7.0.9.tar.gz` is assembled by upstream's release tooling with all submodules bundled. It is byte-identical to the tarball currently fetched from epics-controls.org — `sha256: acd62c9b97b60caea9303cc3aab922dbf2bc3bfb3d20e0027110ffe4c906a6c7` for both — so the checksum is unchanged and no build-script changes are needed.
