### PR TITLE
Split the EPICS build system into a separate `epics-base-devel` output

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -98,8 +98,9 @@ make -j${CPU_COUNT}
 # Relax timer accuracy tolerances on macOS as CI runners seem to struggle keeping up
 [[ "$target_platform" == osx-* ]] && export EPICS_TEST_IMPRECISE_TIMING=YES
 
-# run epics-base tests
-[[ ${PKG_NAME} != "epics-base-static-libs" ]] &&  make -j${CPU_COUNT} runtests
+# run epics-base tests (the staging build runs only once, so no need to guard
+# against re-running the test suite per output)
+make -j${CPU_COUNT} runtests
 
 # Create files to set/unset variables when running
 # activate/deactivate

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -28,8 +28,12 @@ build:
   number: 12
 
 outputs:
-  - package:
-      name: epics-base
+  # Staging output: builds EPICS once; the package outputs below select their
+  # files from this build via `inherit`. Run exports from the staging
+  # dependencies (libgcc, libstdcxx, readline) are appended to the inheriting
+  # outputs automatically.
+  - staging:
+      name: epics-base-staging
     requirements:
       build:
         - ${{ compiler('c') }}
@@ -42,12 +46,18 @@ outputs:
       host:
         - if: unix
           then: readline
+    build:
+      script: build
+
+  - package:
+      name: epics-base
+    inherit: epics-base-staging
+    requirements:
       run:
         - perl
       run_exports:
         - ${{ pin_subpackage('epics-base', upper_bound='x.x.x.x') }}
     build:
-      script: build
       files:
         - etc
         - epics/bin
@@ -106,18 +116,8 @@ outputs:
 
   - package:
       name: epics-base-static-libs
+    inherit: epics-base-staging
     requirements:
-      build:
-        - ${{ compiler('c') }}
-        - ${{ stdlib("c") }}
-        - ${{ compiler('cxx') }}
-        - make
-        - perl
-        - if: win
-          then: m2-patch
-      host:
-        - if: unix
-          then: readline
       run:
         - if: not win
           then: ${{ pin_subpackage('epics-base', exact=True) }}
@@ -125,7 +125,6 @@ outputs:
       run_exports:
         - ${{ pin_subpackage('epics-base', upper_bound='x.x.x.x') }}
     build:
-      script: build
       files:
         - if: not win
           then: epics/lib/*/*.a

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,7 +25,7 @@ source:
         - skip_testCaProvider_on_windows.patch
 
 build:
-  number: 12
+  number: 13
 
 outputs:
   # Staging output: builds EPICS once; the package outputs below select their
@@ -59,28 +59,74 @@ outputs:
         - ${{ pin_subpackage('epics-base', upper_bound='x.x.x.x') }}
     build:
       files:
-        - etc
-        - epics/bin
-        - epics/cfg
-        - epics/configure
-        - epics/db
-        - epics/dbd
-        - epics/html
-        - epics/include
-        # windows .dll are under bin
-        - if: win
-          then:
-            - epics/bin/*/*.dll
-            - epics/lib/*/*.lib
-            - Library/lib/*.lib
-            - Library/bin/*.dll
-        - if: osx
-          then: epics/lib/*/*.dylib
-        - if: linux
-          then: epics/lib/*/*.so*
-        - epics/lib/perl
-        - epics/lib/pkgconfig
-        - epics/templates
+        include:
+          - etc
+          - epics/bin
+          - epics/db
+          - epics/dbd
+          - epics/html
+          - epics/include
+          # windows .dll are under bin
+          - if: win
+            then:
+              - epics/bin/*/*.dll
+              - epics/lib/*/*.lib
+              - Library/lib/*.lib
+              - Library/bin/*.dll
+          - if: osx
+            then: epics/lib/*/*.dylib
+          - if: linux
+            then: epics/lib/*/*.so*
+          # runtime pieces of lib/perl; the build-time perl modules belong to
+          # epics-base-devel. The perl CA bindings are not built on win.
+          - if: not win
+            then:
+              - epics/lib/perl/CA.pm
+              - epics/lib/perl/5*/**
+          - epics/lib/perl/EpicsHostArch.pl
+          - epics/lib/pkgconfig
+        # everything under bin that is part of the EPICS build system; keep in
+        # sync with the epics-base-devel include list
+        exclude:
+          - epics/bin/*/assembleSnippets.pl
+          - epics/bin/*/bldEnvData.pl
+          - epics/bin/*/convertRelease.pl
+          - epics/bin/*/cvsclean.pl
+          - epics/bin/*/dbExpand.pl
+          - epics/bin/*/dbdExpand.pl
+          - epics/bin/*/dbdToHtml.pl
+          - epics/bin/*/dbdToMD.pl
+          - epics/bin/*/dbdToMenuH.pl
+          - epics/bin/*/dbdToRecordtypeH.pl
+          - epics/bin/*/depclean.pl
+          - epics/bin/*/dos2unix.pl
+          - epics/bin/*/epicsMakeMemFs.pl
+          - epics/bin/*/epicsProve.pl
+          - epics/bin/*/expandVars.pl
+          - epics/bin/*/filterMakeflags.pl
+          - epics/bin/*/fullPathName.pl
+          - epics/bin/*/genVersionHeader.pl
+          - epics/bin/*/installEpics.pl
+          - epics/bin/*/makeAPIheader.pl
+          - epics/bin/*/makeBaseApp.pl
+          - epics/bin/*/makeBaseExt.pl
+          - epics/bin/*/makeIncludeDbd.pl
+          - epics/bin/*/makeMakefile.pl
+          - epics/bin/*/makeTestfile.pl
+          - epics/bin/*/mkmf.pl
+          - epics/bin/*/munch.pl
+          - epics/bin/*/podRemove.pl
+          - epics/bin/*/podToHtml.pl
+          - epics/bin/*/podToMD.pl
+          - epics/bin/*/registerRecordDeviceDriver.pl
+          - epics/bin/*/replaceVAR.pl
+          - epics/bin/*/tap-to-junit-xml.pl
+          - epics/bin/*/testFailures.pl
+          - epics/bin/*/useManifestTool.pl
+          - epics/bin/*/antelope*
+          - epics/bin/*/e_flex*
+          - epics/bin/*/makeBpt*
+          - epics/bin/*/makeRPath.py
     tests:
       - script:
           - caget -h
@@ -100,6 +146,19 @@ outputs:
               - test -f ${EPICS_BASE}/include/epicsVersion.h
               - test -f ${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libCom${SHLIB_EXT}
               - test -f ${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libca${SHLIB_EXT}
+              # runtime perl pieces stay in this package; on cross-compiled
+              # variants the perl CA bindings are only built for the build
+              # machine arch, so locate capr.pl with a glob
+              - test -f ${EPICS_BASE}/bin/*/capr.pl
+              - test -f ${EPICS_BASE}/lib/perl/CA.pm
+              - test -f ${EPICS_BASE}/lib/perl/EpicsHostArch.pl
+              # msi stays in the runtime package: IOC startup scripts use it
+              # to expand templates
+              - test -x ${EPICS_BASE}/bin/${EPICS_HOST_ARCH}/msi
+              # the build system is split out into epics-base-devel
+              - test ! -d ${EPICS_BASE}/configure
+              - test ! -d ${EPICS_BASE}/templates
+              - test ! -f ${EPICS_BASE}/bin/${EPICS_HOST_ARCH}/makeBaseApp.pl
           - if: win
             then:
               - if not exist %EPICS_BASE%\bin\%EPICS_HOST_ARCH%\caget.exe exit 1
@@ -110,9 +169,91 @@ outputs:
               - if not exist %EPICS_BASE%\lib\%EPICS_HOST_ARCH%\Com.lib exit 1
               - if not exist %PREFIX%\Library\bin\Com.dll exit 1
               - if not exist %PREFIX%\Library\lib\Com.lib exit 1
+              - if not exist %EPICS_BASE%\lib\perl\EpicsHostArch.pl exit 1
+              - if not exist %EPICS_BASE%\bin\%EPICS_HOST_ARCH%\msi.exe exit 1
+              - if exist %EPICS_BASE%\configure exit 1
+              - if exist %EPICS_BASE%\templates exit 1
+              - if exist %EPICS_BASE%\bin\%EPICS_HOST_ARCH%\makeBaseApp.pl exit 1
         files:
           source:
             - modules/pva2pva/loopback.conf
+
+  # The EPICS build system: the configure/RULES tree and the tools it invokes
+  # during module/application builds, plus the makeBaseApp scaffolding. Module
+  # recipes list this package in host next to epics-base; build tools (make,
+  # and for cross-compilation a build-platform perl) stay build dependencies
+  # of the consumer.
+  - package:
+      name: epics-base-devel
+    inherit: epics-base-staging
+    requirements:
+      run:
+        # the interpreter for the perl scripts this package ships; make stays
+        # a build dependency of the consumer, as for any other build tool.
+        # Cross-compiling consumers also declare perl in build, as today: this
+        # one is the target-platform perl.
+        - perl
+        - ${{ pin_subpackage('epics-base', exact=True) }}
+      run_exports:
+        - ${{ pin_subpackage('epics-base', upper_bound='x.x.x.x') }}
+    build:
+      files:
+        include:
+          - epics/configure
+          - epics/cfg
+          - epics/templates
+          - epics/lib/perl
+          # build-system tools under bin; keep in sync with the epics-base
+          # exclude list
+          - epics/bin/*/*.pl
+          - epics/bin/*/antelope*
+          - epics/bin/*/e_flex*
+          - epics/bin/*/makeBpt*
+          # invoked as $(PYTHON) makeRPath.py, and only when a consumer opts
+          # into LINKER_USE_RPATH=ORIGIN; such consumers declare python in
+          # build themselves, so it is not a run dependency here
+          - epics/bin/*/makeRPath.py
+        # runtime perl pieces that stay in epics-base
+        exclude:
+          - epics/bin/*/capr.pl
+          - epics/lib/perl/CA.pm
+          - epics/lib/perl/EpicsHostArch.pl
+          - epics/lib/perl/5*/**
+    tests:
+      - script:
+          # perl must arrive as a run dependency of this package
+          - perl --version
+          - if: not win
+            then:
+              - test -f ${EPICS_BASE}/configure/CONFIG_BASE
+              - test -f ${EPICS_BASE}/configure/RULES
+              - test -d ${EPICS_BASE}/cfg
+              - test -d ${EPICS_BASE}/templates/makeBaseApp
+              - test -f ${EPICS_BASE}/bin/${EPICS_HOST_ARCH}/makeBaseApp.pl
+              - test -f ${EPICS_BASE}/lib/perl/EPICS/Getopts.pm
+              # pulled in via the exact epics-base run dependency
+              - test -f ${EPICS_BASE}/lib/${EPICS_HOST_ARCH}/libCom${SHLIB_EXT}
+          - if: win
+            then:
+              - if not exist %EPICS_BASE%\configure\CONFIG_BASE exit 1
+              - if not exist %EPICS_BASE%\bin\%EPICS_HOST_ARCH%\makeBaseApp.pl exit 1
+              - if not exist %EPICS_BASE%\lib\perl\EPICS\Getopts.pm exit 1
+      # Scaffold an IOC application with makeBaseApp and build it against the
+      # installed epics-base, with only this package's run dependencies plus
+      # make and the compilers.
+      - if: linux
+        then:
+          - script:
+              - cd "$(mktemp -d)"
+              - makeBaseApp.pl -t ioc scratch
+              - make
+              - test -x bin/${EPICS_HOST_ARCH}/scratch
+            requirements:
+              run:
+                - ${{ compiler('c') }}
+                - ${{ compiler('cxx') }}
+                - ${{ stdlib("c") }}
+                - make
 
   - package:
       name: epics-base-static-libs


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

**RFC / draft** — this proposes a repackaging and deliberately changes what the name `epics-base` provides, so it should not merge without maintainer consensus. Feedback wanted, particularly from consumers who build EPICS modules against this package.

## What

`epics-base` currently ships two different things in one package: the runtime (libraries, CLI/IOC binaries, db/dbd, headers) and the EPICS build system (the `configure`/RULES tree, `cfg`, the makeBaseApp templates, and the tools RULES invokes — 35 perl scripts, `antelope`, `e_flex`, `makeBpt`, `makeRPath.py`). This PR moves the build system into a new output, `epics-base-devel`, which:

* has `run: perl` — the interpreter for the scripts it ships;
* exactly pins `epics-base`, so installing it always brings the matching runtime;
* carries the same weak `run_exports`, so consumers get the `epics-base` runtime pin automatically.

`msi` stays in `epics-base`: although the build system invokes it, IOC startup scripts also use it to expand templates at runtime; module builds still find it through the exact `epics-base` pin. The runtime perl pieces (the CA bindings, `capr.pl`, and `EpicsHostArch.pl`, which the osx-arm64 activation script runs) also stay in `epics-base`, which therefore keeps its own `perl` dependency. `epics-base-static-libs` is unchanged. The packages partition the previous file set exactly — nothing dropped, nothing duplicated.

## Why `-devel`, and why a host dependency

The EPICS build facility cannot be a `build:` dependency the way CMake is: it is a make-include framework that must reside *inside* the `EPICS_BASE` tree it describes. Modules include `$(EPICS_BASE)/configure/CONFIG` and link `$(EPICS_BASE)/lib` from that same single tree, and RULES invokes its helper tools via `$(EPICS_BASE)/bin/$(EPICS_HOST_ARCH)/…`. Placing the package in `build:` would put the configure tree in `$BUILD_PREFIX`, disconnected from the libraries in `$PREFIX`, which the framework cannot express. This is a property of the EPICS build facility, not a packaging choice — if upstream ever makes it relocatable, this could become a true build-tool package.

That usage pattern is exactly the `-devel` contract — install it in host to build against EPICS base — hence the name. Headers and pkgconfig files stay in `epics-base`, as is customary on conda-forge; the exact pin brings them along, so installing `epics-base-devel` still yields everything needed to compile and link.

## Why split at all

* Everything that requires the EPICS base build system gets it explicitly, from a package that says so — instead of implicitly from the runtime package.
* Production IOC environments stop carrying RULES, build scripts, scaffolding templates and yacc/lex ports they never execute (~470 files).
* The runtime pin a module needs arrives via the run_exports of the thing the module actually uses at build time.

A module recipe changes from:

```diff
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
     - make
-    - perl
   host:
-    - epics-base
+    - epics-base
+    - epics-base-devel
     - pvxs
```

and its published run dependencies still gain the pinned `epics-base` requirement via run_exports, with no build tooling at runtime. Cross-compiling consumer recipes keep `make` and `perl` in `build:` exactly as they do today — the new output's `perl` run dependency is the target-platform interpreter for the scripts it ships, which serves native builds and interactive use.

## Breaking change

Installed environments and already-built module binaries are unaffected (nothing reads `configure/` at IOC runtime). **Module-recipe rebuilds break loudly** — `$(EPICS_BASE)/configure` no longer exists until the recipe adds `epics-base-devel` to host. That's a one-line fix, but it's the reason this is an RFC.

The new output would need to be added to the feedstock's allowed outputs ([`conda_forge_output_validation`](https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens)).
